### PR TITLE
Add terminal.border color

### DIFF
--- a/themes/September Steel-color-theme.json
+++ b/themes/September Steel-color-theme.json
@@ -95,6 +95,7 @@
     "terminal.ansiWhite": "#bbbbbb",
     "terminal.ansiYellow": "#e5c07b",
     "terminal.background": "#252930",
+    "terminal.border": "#2f333d",
     "titleBar.activeBackground": "#282c34",
     "titleBar.activeForeground": "#9da5b4",
     "titleBar.border": "#23272E",


### PR DESCRIPTION
![integrated terminal split border](https://user-images.githubusercontent.com/5196786/37254403-482b6f24-254e-11e8-8a43-312a2070d6b2.png)

Added splitted integrated terminal border color. I'm not sure about this color. I'm not good at choosing colors. You decide better than me :)