### PR TITLE
Update scope names of list style and inline code in Markdown

### DIFF
--- a/themes/September Steel-color-theme.json
+++ b/themes/September Steel-color-theme.json
@@ -601,7 +601,7 @@
     },
     {
       "scope": [
-        "beginning.punctuation.definition.list.markdown"
+        "punctuation.definition.list.begin.markdown"
       ],
       "settings": {
         "foreground": "#98c379"
@@ -652,7 +652,7 @@
     },
     {
       "scope": [
-        "markup.inline.raw.markdown",
+        "markup.inline.raw.string.markdown",
         "markup.raw.block.markdown",
         "markup.fenced_code.block.markdown"
       ],


### PR DESCRIPTION
Visual Studio Code had changed some syntax in Markdown, which make some highlighting not work.
* [list style](https://github.com/Microsoft/vscode-markdown-tm-grammar/commit/935f7a6d1da73e16231be18c545d7991d3698075)
* [inline code](https://github.com/Microsoft/vscode/commit/0ff02b2df7dd4e76faa8e270c99df31f89cdf38d)

![before](https://user-images.githubusercontent.com/44085121/46869669-1edfd280-ce5f-11e8-89e2-5cf27c604c31.png)

![after](https://user-images.githubusercontent.com/44085121/46869676-22735980-ce5f-11e8-8661-a43ce9e59772.png)

Thank you for this pretty work. This is my favorite editor theme.