### PR TITLE
Add VScode remote status bar item colors

### DIFF
--- a/themes/September Steel-color-theme.json
+++ b/themes/September Steel-color-theme.json
@@ -83,6 +83,8 @@
     "statusBar.foreground": "#9da5b4",
     "statusBar.noFolderBackground": "#21252b",
     "statusBarItem.hoverBackground": "#2c313a",
+    "statusBarItem.remoteBackground": "#99a1af",
+    "statusBarItem.remoteForeground": "#282c34",
     "tab.hoverBackground": "#2F333D",
     "tab.unfocusedHoverBorder": "#2F333D",
     "tab.activeForeground": "#ffffff",


### PR DESCRIPTION
This can be temporary customized in `settings.json` with:

```
    "workbench.colorCustomizations": {
        "statusBarItem.remoteBackground": "#99a1af",
        "statusBarItem.remoteForeground": "#282c34",
    },
```

Before

![image](https://user-images.githubusercontent.com/645641/84032722-0ad3d780-a998-11ea-8af8-9de990f55c79.png)

After

![image](https://user-images.githubusercontent.com/645641/84032669-fa236180-a997-11ea-814a-2ef0305ed597.png)

